### PR TITLE
Retry deploy issue (MK-37)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,8 @@ tasks.named('asciidoctor') {
 }
 
 asciidoctor.doFirst {
+    if (file('build/generated-snippets'))
+        mkdir 'build/generated-snippets'
     if (file('src/main/resources/static/docs'))
         delete file('src/main/resources/static/docs')
 }


### PR DESCRIPTION
- build/generated-snippets 디렉터리가 없어서 발생하는 오류로 생각된다.
- asciidoctor task가 실행될 때 오류가 발생하므로 asciidoctor task의 doFirst에서 디렉터리가 없으면 생성하는 방식으로 설정했다.