### PR TITLE
Fix deploy issue (MK-37)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,13 +8,13 @@ pipeline {
     stages {
         stage('Checkout') {
             steps {
-                git branch: 'fix/MK-37',
+                git branch: 'main',
                     credentialsId: 'jenkins-github-access-token',
                     url: 'https://github.com/geezers-io/mogakco-back.git'
             }
         }
 
-        stage('Build') {
+        stage('Test and Build') {
             steps {
                 sh '''
                     ./jenkins/build/build.sh

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,20 +14,6 @@ pipeline {
             }
         }
 
-        stage('Test') {
-            steps {
-                sh './jenkins/test/test.sh'
-            }
-            post {
-                success {
-                    echo '**** Test success ****'
-                }
-                failure {
-                    echo '**** Test failed ****'
-                }
-            }
-        }
-
         stage('Build') {
             steps {
                 sh '''

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,9 +8,23 @@ pipeline {
     stages {
         stage('Checkout') {
             steps {
-                git branch: 'main',
+                git branch: 'fix/MK-37',
                     credentialsId: 'jenkins-github-access-token',
                     url: 'https://github.com/geezers-io/mogakco-back.git'
+            }
+        }
+
+        stage('Test') {
+            steps {
+                sh './jenkins/test/test.sh'
+            }
+            post {
+                success {
+                    echo '**** Test success ****'
+                }
+                failure {
+                    echo '**** Test failed ****'
+                }
             }
         }
 
@@ -26,20 +40,6 @@ pipeline {
                 }
                 failure {
                     echo '**** build failed ****'
-                }
-            }
-        }
-
-        stage('Test') {
-            steps {
-                sh './jenkins/test/test.sh'
-            }
-            post {
-                success {
-                    echo '**** Test success ****'
-                }
-                failure {
-                    echo '**** Test failed ****'
                 }
             }
         }

--- a/jenkins/build/build.sh
+++ b/jenkins/build/build.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-echo "**********************"
-echo "**** Building jar ****"
-echo "**********************"
+echo "**********************************"
+echo "**** Testing and Building jar ****"
+echo "**********************************"
 
-./gradlew build -x test
+./gradlew clean build
 
 echo "*******************************"
 echo "**** Building Docker Image ****"

--- a/jenkins/build/build.sh
+++ b/jenkins/build/build.sh
@@ -4,7 +4,7 @@ echo "**********************"
 echo "**** Building jar ****"
 echo "**********************"
 
-./gradlew clean build -x test
+./gradlew build -x test
 
 echo "*******************************"
 echo "**** Building Docker Image ****"

--- a/jenkins/test/test.sh
+++ b/jenkins/test/test.sh
@@ -4,4 +4,4 @@ echo "**********************"
 echo "****** Testing *******"
 echo "**********************"
 
-./gradlew test
+./gradlew clean test


### PR DESCRIPTION
1. 처음에는 build 디렉터리가 없어서 발생하는 오류로 판단하여 build.gradle에 asciidoctor task를 수행하기 전에 디렉터리를 만들면 될 것으로 생각했다. 하지만 같은 오류가 발생했다.
2. test > build 로 순서를 변경하면 generated-snippets가 생성되니  해결될 것이라 생각했다. 하지만 같은 오류가 발생했다.
3. test와 build 과정을 면밀히 살펴보니 test에서 생성된 generated-snippets 디렉터리를 build 실행 중 asciidoctor task가 지워버리는 상황을 발견했다. task 자체에서 지운 다음 다시 디렉터리를 찾는 게 의문이다. 결국 test와 build를 함께 수행하는 gradle clean build로 변경하기로 결정했다.