### PR TITLE
Add Weblog filter (MK-43)

### DIFF
--- a/src/main/java/io/geezers/mogakco/api/common/SimpleWeblogFilter.java
+++ b/src/main/java/io/geezers/mogakco/api/common/SimpleWeblogFilter.java
@@ -27,7 +27,7 @@ public class SimpleWeblogFilter implements Filter {
             double endTimeNano = System.nanoTime();
             double processingTimeNano = endTimeNano - startTimeNano;
             double processingTimeMillis = processingTimeNano / 1000 / 1000;
-            double processingTimeMillisRoundedToThreeDecimalPlaces = ((double) Math.round(processingTimeMillis) * 1000) / 1000;
+            double processingTimeMillisRoundedToThreeDecimalPlaces = Math.round(processingTimeMillis * 1000) / 1000.0;
 
             String method = request.getMethod();
             String requestURI = request.getRequestURI();

--- a/src/main/java/io/geezers/mogakco/api/common/SimpleWeblogFilter.java
+++ b/src/main/java/io/geezers/mogakco/api/common/SimpleWeblogFilter.java
@@ -1,0 +1,42 @@
+package io.geezers.mogakco.api.common;
+
+import lombok.extern.slf4j.Slf4j;
+
+import javax.servlet.*;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@Slf4j
+public class SimpleWeblogFilter implements Filter {
+
+    @Override
+    public void init(FilterConfig filterConfig) {}
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) {
+        doFilter((HttpServletRequest) request, (HttpServletResponse) response, chain);
+    }
+
+    private void doFilter(HttpServletRequest request, HttpServletResponse response, FilterChain chain) {
+        double startTimeNano = System.nanoTime();
+        try {
+            chain.doFilter(request, response);
+        } catch (Exception e) {
+            log.error("Unhandled Error", e);
+        } finally {
+            double endTimeNano = System.nanoTime();
+            double processingTimeNano = endTimeNano - startTimeNano;
+            double processingTimeMillis = processingTimeNano / 1000 / 1000;
+            double processingTimeMillisRoundedToThreeDecimalPlaces = ((double) Math.round(processingTimeMillis) * 1000) / 1000;
+
+            String method = request.getMethod();
+            String requestURI = request.getRequestURI();
+            int status = response.getStatus();
+
+            log.info("{} {} {} - {} ms", method, requestURI, status, processingTimeMillisRoundedToThreeDecimalPlaces);
+        }
+    }
+
+    @Override
+    public void destroy() {}
+}

--- a/src/main/java/io/geezers/mogakco/web/config/WebConfig.java
+++ b/src/main/java/io/geezers/mogakco/web/config/WebConfig.java
@@ -1,0 +1,24 @@
+package io.geezers.mogakco.web.config;
+
+import io.geezers.mogakco.api.common.SimpleWeblogFilter;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import javax.servlet.Filter;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Bean
+    public FilterRegistrationBean<Filter> filterRegistrationBean() {
+        FilterRegistrationBean<Filter> filterRegistrationBean = new FilterRegistrationBean<>();
+
+        filterRegistrationBean.setFilter(new SimpleWeblogFilter());
+        filterRegistrationBean.setOrder(-104);
+        filterRegistrationBean.addUrlPatterns("/api/*");
+
+        return filterRegistrationBean;
+    }
+}


### PR DESCRIPTION
- 이 필터는 보안 관련 필터가 아니므로 Spring Security의 filter chain에 넣을 필요가 없다고 판단했다. 그래서 springSecurityfilterChain의 앞에 위치하게 하여 요청과 응답에 관한 로깅을 하도록 했다.
- springSecurityFilterChain의 default order는 -100이다.
- OrderedRequestContextFilter의 default order는 -105이다.
- 따라서 그 중간에 끼우기 위해 order를 -104로 지정했다.