### PR TITLE
Fix authentication logic of session id (MK-50)

### DIFF
--- a/src/main/java/io/geezers/mogakco/api/common/SimpleWeblogFilter.java
+++ b/src/main/java/io/geezers/mogakco/api/common/SimpleWeblogFilter.java
@@ -27,7 +27,7 @@ public class SimpleWeblogFilter implements Filter {
             double endTimeNano = System.nanoTime();
             double processingTimeNano = endTimeNano - startTimeNano;
             double processingTimeMillis = processingTimeNano / 1000 / 1000;
-            double processingTimeMillisRoundedToThreeDecimalPlaces = ((double) Math.round(processingTimeMillis) * 1000) / 1000;
+            double processingTimeMillisRoundedToThreeDecimalPlaces = Math.round(processingTimeMillis * 1000) / 1000.0;
 
             String method = request.getMethod();
             String requestURI = request.getRequestURI();

--- a/src/main/java/io/geezers/mogakco/api/common/SimpleWeblogFilter.java
+++ b/src/main/java/io/geezers/mogakco/api/common/SimpleWeblogFilter.java
@@ -1,0 +1,42 @@
+package io.geezers.mogakco.api.common;
+
+import lombok.extern.slf4j.Slf4j;
+
+import javax.servlet.*;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@Slf4j
+public class SimpleWeblogFilter implements Filter {
+
+    @Override
+    public void init(FilterConfig filterConfig) {}
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) {
+        doFilter((HttpServletRequest) request, (HttpServletResponse) response, chain);
+    }
+
+    private void doFilter(HttpServletRequest request, HttpServletResponse response, FilterChain chain) {
+        double startTimeNano = System.nanoTime();
+        try {
+            chain.doFilter(request, response);
+        } catch (Exception e) {
+            log.error("Unhandled Error", e);
+        } finally {
+            double endTimeNano = System.nanoTime();
+            double processingTimeNano = endTimeNano - startTimeNano;
+            double processingTimeMillis = processingTimeNano / 1000 / 1000;
+            double processingTimeMillisRoundedToThreeDecimalPlaces = ((double) Math.round(processingTimeMillis) * 1000) / 1000;
+
+            String method = request.getMethod();
+            String requestURI = request.getRequestURI();
+            int status = response.getStatus();
+
+            log.info("{} {} {} - {} ms", method, requestURI, status, processingTimeMillisRoundedToThreeDecimalPlaces);
+        }
+    }
+
+    @Override
+    public void destroy() {}
+}

--- a/src/main/java/io/geezers/mogakco/api/user/UserApiController.java
+++ b/src/main/java/io/geezers/mogakco/api/user/UserApiController.java
@@ -11,7 +11,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
@@ -48,9 +47,8 @@ public class UserApiController {
     }
 
     @GetMapping("/authentication")
-    public ResponseEntity<Void> authenticate(Authentication authentication) {
-        Object principal = authentication.getPrincipal();
-        if (principal == null) {
+    public ResponseEntity<Void> authenticate(HttpServletRequest request) {
+        if (request.getSession(false) == null) {
             return ResponseEntity.status(HttpServletResponse.SC_UNAUTHORIZED).build();
         }
         return ResponseEntity.status(HttpServletResponse.SC_OK).build();

--- a/src/main/java/io/geezers/mogakco/security/config/SecurityConfig.java
+++ b/src/main/java/io/geezers/mogakco/security/config/SecurityConfig.java
@@ -48,6 +48,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         http.authorizeRequests()
                 .antMatchers(DEFAULT_ACCESS_WHITELIST).permitAll()
                 .antMatchers(HttpMethod.POST, Endpoint.Api.USER).permitAll()
+                .antMatchers(HttpMethod.GET, Endpoint.Api.AUTH).permitAll()
                 .anyRequest().authenticated();
         http
                 .formLogin().disable();

--- a/src/main/java/io/geezers/mogakco/web/config/WebConfig.java
+++ b/src/main/java/io/geezers/mogakco/web/config/WebConfig.java
@@ -1,0 +1,24 @@
+package io.geezers.mogakco.web.config;
+
+import io.geezers.mogakco.api.common.SimpleWeblogFilter;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import javax.servlet.Filter;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Bean
+    public FilterRegistrationBean<Filter> filterRegistrationBean() {
+        FilterRegistrationBean<Filter> filterRegistrationBean = new FilterRegistrationBean<>();
+
+        filterRegistrationBean.setFilter(new SimpleWeblogFilter());
+        filterRegistrationBean.setOrder(-104);
+        filterRegistrationBean.addUrlPatterns("/api/*");
+
+        return filterRegistrationBean;
+    }
+}

--- a/src/test/java/io/geezers/mogakco/api/UserApiControllerTest.java
+++ b/src/test/java/io/geezers/mogakco/api/UserApiControllerTest.java
@@ -16,6 +16,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpSession;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.security.test.context.support.WithMockUser;
@@ -53,26 +54,30 @@ class UserApiControllerTest {
 
     @BeforeEach
     public void setUp(WebApplicationContext webApplicationContext, RestDocumentationContextProvider restDocumentation) {
-        this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
+        this.mockMvc = MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
                 .apply(documentationConfiguration(restDocumentation)
-                        .operationPreprocessors()
-                        .withRequestDefaults(prettyPrint(), removeHeaders("Host"))
-                        .withResponseDefaults(prettyPrint()))
-                .apply(springSecurity()).build();
+                               .operationPreprocessors()
+                               .withRequestDefaults(prettyPrint(), removeHeaders("Host"))
+                               .withResponseDefaults(prettyPrint()))
+                .apply(springSecurity())
+                .build();
     }
 
     @DisplayName("인증 상태 검증 성공")
-    @WithMockUser
     @Test
     void testAuthenticationVerifyingSuccess() throws Exception {
-        mockMvc.perform(get(Endpoint.Api.AUTH))
+        MockHttpSession mockHttpSession = new MockHttpSession();
+        mockMvc
+                .perform(get(Endpoint.Api.AUTH).session(mockHttpSession))
                 .andExpect(status().isOk());
     }
 
     @DisplayName("인증 상태 검증 실패")
     @Test
     void testAuthenticationVerifyingFailed() throws Exception {
-        mockMvc.perform(get(Endpoint.Api.AUTH))
+        mockMvc
+                .perform(get(Endpoint.Api.AUTH))
                 .andExpect(status().isUnauthorized());
     }
 
@@ -81,25 +86,28 @@ class UserApiControllerTest {
     void testSignupIsSuccess() throws Exception {
         UserSignupRequestDto signupRequestDto = getUserSignupRequestDto(getValidEmail(), getValidPassword());
 
-        mockMvc.perform(post(Endpoint.Api.USER)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(signupRequestDto)))
+        mockMvc
+                .perform(post(Endpoint.Api.USER)
+                                 .contentType(MediaType.APPLICATION_JSON)
+                                 .content(objectMapper.writeValueAsString(signupRequestDto)))
                 .andExpect(status().isCreated())
-                .andDo(document("signup",
-                        requestFields(
-                                attributes(
-                                        key("title").value("Data Params"), key("url").value(Endpoint.Api.USER),
-                                        key("method").value("POST")),
-                                fieldWithPath("email").description("").
-                                        attributes(key("required").value("O"))
-                                        .attributes(key("constraints").value("@Email 형식을 맞추어야 함")),
-                                fieldWithPath("password").description("")
-                                        .attributes(key("required").value("O"))
-                                        .attributes(key("constraints").value("Null 불가, 빈 문자열 불가")))));
+                .andDo(document("signup", requestFields(
+                        attributes(key("title").value("Data Params"), key("url").value(Endpoint.Api.USER),
+                                   key("method").value("POST")), fieldWithPath("email")
+                                .description("")
+                                .attributes(key("required").value("O"))
+                                .attributes(key("constraints").value("@Email 형식을 맞추어야 함")), fieldWithPath("password")
+                                .description("")
+                                .attributes(key("required").value("O"))
+                                .attributes(key("constraints").value("Null 불가, 빈 문자열 불가")))));
     }
 
     private UserSignupRequestDto getUserSignupRequestDto(String email, String password) {
-        return UserSignupRequestDto.builder().email(email).password(password).build();
+        return UserSignupRequestDto
+                .builder()
+                .email(email)
+                .password(password)
+                .build();
     }
 
     private String getValidPassword() {
@@ -117,9 +125,10 @@ class UserApiControllerTest {
         UserSignupRequestDto signupRequestDto = getUserSignupRequestDto(getValidEmail(), getValidPassword());
         userApiController.signup(signupRequestDto, request);
 
-        mockMvc.perform(post(Endpoint.Api.USER)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(signupRequestDto)))
+        mockMvc
+                .perform(post(Endpoint.Api.USER)
+                                 .contentType(MediaType.APPLICATION_JSON)
+                                 .content(objectMapper.writeValueAsString(signupRequestDto)))
                 .andExpect(status().isConflict());
     }
 
@@ -129,9 +138,10 @@ class UserApiControllerTest {
     void testSignupIsFailedByEmailFormat(String invalidEmail) throws Exception {
         UserSignupRequestDto signupRequestDto = getUserSignupRequestDto(invalidEmail, getValidPassword());
 
-        mockMvc.perform(post(Endpoint.Api.USER)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(signupRequestDto)))
+        mockMvc
+                .perform(post(Endpoint.Api.USER)
+                                 .contentType(MediaType.APPLICATION_JSON)
+                                 .content(objectMapper.writeValueAsString(signupRequestDto)))
                 .andExpect(status().isBadRequest());
     }
 
@@ -141,9 +151,10 @@ class UserApiControllerTest {
     void testSignupIsFailedByEmptyEmail(String emptyEmail) throws Exception {
         UserSignupRequestDto signupRequestDto = getUserSignupRequestDto(emptyEmail, getValidPassword());
 
-        mockMvc.perform(post(Endpoint.Api.USER)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(signupRequestDto)))
+        mockMvc
+                .perform(post(Endpoint.Api.USER)
+                                 .contentType(MediaType.APPLICATION_JSON)
+                                 .content(objectMapper.writeValueAsString(signupRequestDto)))
                 .andExpect(status().isBadRequest());
     }
 
@@ -153,9 +164,10 @@ class UserApiControllerTest {
     void testSignupIsFailedByEmptyPassword(String emptyPassword) throws Exception {
         UserSignupRequestDto signupRequestDto = getUserSignupRequestDto(getValidEmail(), emptyPassword);
 
-        mockMvc.perform(post(Endpoint.Api.USER)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(signupRequestDto)))
+        mockMvc
+                .perform(post(Endpoint.Api.USER)
+                                 .contentType(MediaType.APPLICATION_JSON)
+                                 .content(objectMapper.writeValueAsString(signupRequestDto)))
                 .andExpect(status().isBadRequest());
     }
 
@@ -169,25 +181,28 @@ class UserApiControllerTest {
 
         UserLoginRequestDto loginRequestDto = getLoginRequestDto(getValidEmail(), getValidPassword());
 
-        mockMvc.perform(post(Endpoint.Api.LOGIN)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(loginRequestDto)))
+        mockMvc
+                .perform(post(Endpoint.Api.LOGIN)
+                                 .contentType(MediaType.APPLICATION_JSON)
+                                 .content(objectMapper.writeValueAsString(loginRequestDto)))
                 .andExpect(status().isOk())
-                .andDo(document("login",
-                        requestFields(
-                                attributes(
-                                        key("title").value("Data Params"), key("url").value(Endpoint.Api.LOGIN),
-                                        key("method").value("POST")),
-                                fieldWithPath("email").description("").
-                                        attributes(key("required").value("O"))
-                                        .attributes(key("constraints").value("@Email 형식을 맞추어야 함")),
-                                fieldWithPath("password").description("")
-                                        .attributes(key("required").value("O"))
-                                        .attributes(key("constraints").value("Null 불가, 빈 문자열 불가")))));
+                .andDo(document("login", requestFields(
+                        attributes(key("title").value("Data Params"), key("url").value(Endpoint.Api.LOGIN),
+                                   key("method").value("POST")), fieldWithPath("email")
+                                .description("")
+                                .attributes(key("required").value("O"))
+                                .attributes(key("constraints").value("@Email 형식을 맞추어야 함")), fieldWithPath("password")
+                                .description("")
+                                .attributes(key("required").value("O"))
+                                .attributes(key("constraints").value("Null 불가, 빈 문자열 불가")))));
     }
 
     private UserLoginRequestDto getLoginRequestDto(String email, String password) {
-        return UserLoginRequestDto.builder().email(email).password(password).build();
+        return UserLoginRequestDto
+                .builder()
+                .email(email)
+                .password(password)
+                .build();
     }
 
     @DisplayName("회원가입 하지 않은 이메일로 로그인 시도로 인한 로그인 실패")
@@ -195,9 +210,10 @@ class UserApiControllerTest {
     void testLoginIsFailedByNotExistEmail() throws Exception {
         UserLoginRequestDto loginRequestDto = getLoginRequestDto(getNotExistEmail(), getValidPassword());
 
-        mockMvc.perform(post(Endpoint.Api.LOGIN)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(loginRequestDto)))
+        mockMvc
+                .perform(post(Endpoint.Api.LOGIN)
+                                 .contentType(MediaType.APPLICATION_JSON)
+                                 .content(objectMapper.writeValueAsString(loginRequestDto)))
                 .andExpect(status().isUnauthorized());
     }
 
@@ -211,9 +227,10 @@ class UserApiControllerTest {
     void testLoginIsFailedByEmailFormat(String invalidEmail) throws Exception {
         UserLoginRequestDto loginRequestDto = getLoginRequestDto(invalidEmail, getValidPassword());
 
-        mockMvc.perform(post(Endpoint.Api.LOGIN)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(loginRequestDto)))
+        mockMvc
+                .perform(post(Endpoint.Api.LOGIN)
+                                 .contentType(MediaType.APPLICATION_JSON)
+                                 .content(objectMapper.writeValueAsString(loginRequestDto)))
                 .andExpect(status().isUnauthorized());
     }
 
@@ -223,9 +240,10 @@ class UserApiControllerTest {
     void testLoginIsFailedByEmptyEmail(String emptyEmail) throws Exception {
         UserLoginRequestDto loginRequestDto = getLoginRequestDto(emptyEmail, getValidPassword());
 
-        mockMvc.perform(post(Endpoint.Api.LOGIN)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(loginRequestDto)))
+        mockMvc
+                .perform(post(Endpoint.Api.LOGIN)
+                                 .contentType(MediaType.APPLICATION_JSON)
+                                 .content(objectMapper.writeValueAsString(loginRequestDto)))
                 .andExpect(status().isBadRequest());
     }
 
@@ -235,9 +253,10 @@ class UserApiControllerTest {
     void testLoginIsFailedByEmptyPassword(String emptyPassword) throws Exception {
         UserLoginRequestDto loginRequestDto = getLoginRequestDto(getValidEmail(), emptyPassword);
 
-        mockMvc.perform(post(Endpoint.Api.LOGIN)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(loginRequestDto)))
+        mockMvc
+                .perform(post(Endpoint.Api.LOGIN)
+                                 .contentType(MediaType.APPLICATION_JSON)
+                                 .content(objectMapper.writeValueAsString(loginRequestDto)))
                 .andExpect(status().isBadRequest());
     }
 
@@ -245,7 +264,8 @@ class UserApiControllerTest {
     @WithMockUser
     @Test
     void testLogoutIsSuccess() throws Exception {
-        mockMvc.perform(post(Endpoint.Api.LOGOUT))
+        mockMvc
+                .perform(post(Endpoint.Api.LOGOUT))
                 .andExpect(status().isOk())
                 .andDo(document("logout"));
     }


### PR DESCRIPTION
# 오류 1. 엔드포인트에 대한 접근을 허용하지 않음
1. Controller 단에서 Authentication 객체는 로그인한 경우에만 주입되고 로그인하지 않은 상태에서는 null이 주입된다.
2. 이 API는 로그인하지 않은 상태에서 세션 ID를 검증해야 하는데  수정 전의 코드는 로그인하지 않으면 세션 ID가 정상이어도 API를 호출할 수 없었다.

# 오류 2. Authentication 객체 주입에 대한 잘못된 이해로 인한 잘못된 로직 작성
1. 1-2과 같은 이유로 로그인하지 않은 유저가 호출 시 Authentication 객체에는 null이 할당된다.
2. 따라서 401 Unauthorized가 아닌 NPE로 인한 500 에러가 발생한다.