### PR TITLE
Fix authentication logic of session id (MK-50)

### DIFF
--- a/src/main/java/io/geezers/mogakco/api/common/CommonApiControllerAdvice.java
+++ b/src/main/java/io/geezers/mogakco/api/common/CommonApiControllerAdvice.java
@@ -28,7 +28,9 @@ public class CommonApiControllerAdvice {
 
     @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
     public ResponseEntity<ErrorResponseDto> handleRequestMethodNotSupportedException(Exception methodArgumentNotValidException) {
-        return getErrorResponseDtoResponseEntity(HttpServletResponse.SC_METHOD_NOT_ALLOWED, methodArgumentNotValidException.getMessage());
+        return getErrorResponseDtoResponseEntity(
+                HttpServletResponse.SC_METHOD_NOT_ALLOWED,
+                methodArgumentNotValidException.getMessage());
     }
 
     @ExceptionHandler

--- a/src/main/java/io/geezers/mogakco/api/user/UserApiController.java
+++ b/src/main/java/io/geezers/mogakco/api/user/UserApiController.java
@@ -11,7 +11,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
@@ -37,7 +36,8 @@ public class UserApiController {
 
         User user = userService.signup(signupRequestDto);
 
-        Me me = Me.builder()
+        Me me = Me
+                .builder()
                 .id(user.getId())
                 .email(user.getEmail())
                 .build();
@@ -48,11 +48,14 @@ public class UserApiController {
     }
 
     @GetMapping("/authentication")
-    public ResponseEntity<Void> authenticate(Authentication authentication) {
-        Object principal = authentication.getPrincipal();
-        if (principal == null) {
-            return ResponseEntity.status(HttpServletResponse.SC_UNAUTHORIZED).build();
+    public ResponseEntity<Void> authenticate(HttpServletRequest request) {
+        if (request.getSession(false) == null) {
+            return ResponseEntity
+                    .status(HttpServletResponse.SC_UNAUTHORIZED)
+                    .build();
         }
-        return ResponseEntity.status(HttpServletResponse.SC_OK).build();
+        return ResponseEntity
+                .status(HttpServletResponse.SC_OK)
+                .build();
     }
 }

--- a/src/main/java/io/geezers/mogakco/api/user/UserApiControllerAdvice.java
+++ b/src/main/java/io/geezers/mogakco/api/user/UserApiControllerAdvice.java
@@ -18,12 +18,17 @@ import static io.geezers.mogakco.api.util.ApiErrorResponseUtil.getErrorResponseD
 public class UserApiControllerAdvice {
 
     @ExceptionHandler(AlreadyUserExistingException.class)
-    public ResponseEntity<ErrorResponseDto> handleAlreadyUserExistingException(AlreadyUserExistingException alreadyUserExistingException) {
-        return getErrorResponseDtoResponseEntity(HttpServletResponse.SC_CONFLICT, alreadyUserExistingException.getMessage());
+    public ResponseEntity<ErrorResponseDto> handleAlreadyUserExistingException(
+            AlreadyUserExistingException alreadyUserExistingException) {
+        return getErrorResponseDtoResponseEntity(
+                HttpServletResponse.SC_CONFLICT,
+                alreadyUserExistingException.getMessage());
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResponseDto> handleBadRequestException(Exception methodArgumentNotValidException) {
-        return getErrorResponseDtoResponseEntity(HttpServletResponse.SC_BAD_REQUEST, methodArgumentNotValidException.getMessage());
+        return getErrorResponseDtoResponseEntity(
+                HttpServletResponse.SC_BAD_REQUEST,
+                methodArgumentNotValidException.getMessage());
     }
 }

--- a/src/main/java/io/geezers/mogakco/api/util/ApiErrorResponseUtil.java
+++ b/src/main/java/io/geezers/mogakco/api/util/ApiErrorResponseUtil.java
@@ -7,9 +7,10 @@ public class ApiErrorResponseUtil {
     public static ResponseEntity<ErrorResponseDto> getErrorResponseDtoResponseEntity(int status, String msg) {
         return ResponseEntity
                 .status(status)
-                .body(ErrorResponseDto.builder()
-                        .status(status)
-                        .message(msg)
-                        .build());
+                .body(ErrorResponseDto
+                              .builder()
+                              .status(status)
+                              .message(msg)
+                              .build());
     }
 }

--- a/src/main/java/io/geezers/mogakco/config/EmbeddedRedisConfig.java
+++ b/src/main/java/io/geezers/mogakco/config/EmbeddedRedisConfig.java
@@ -20,7 +20,8 @@ public class EmbeddedRedisConfig {
 
     @PostConstruct
     public void redisServer() {
-        redisServer = RedisServer.builder()
+        redisServer = RedisServer
+                .builder()
                 .port(port)
                 .setting("maxmemory 128M")
                 .build();

--- a/src/main/java/io/geezers/mogakco/security/config/AjaxLoginConfigurer.java
+++ b/src/main/java/io/geezers/mogakco/security/config/AjaxLoginConfigurer.java
@@ -34,7 +34,8 @@ public class AjaxLoginConfigurer<H extends HttpSecurityBuilder<H>> extends Abstr
             authenticationManager = http.getSharedObject(AuthenticationManager.class);
         }
 
-        SessionAuthenticationStrategy sessionAuthenticationStrategy = http.getSharedObject(SessionAuthenticationStrategy.class);
+        SessionAuthenticationStrategy sessionAuthenticationStrategy = http.getSharedObject(
+                SessionAuthenticationStrategy.class);
 
         if (sessionAuthenticationStrategy != null) {
             getAuthenticationFilter().setSessionAuthenticationStrategy(sessionAuthenticationStrategy);

--- a/src/main/java/io/geezers/mogakco/security/config/SecurityConfig.java
+++ b/src/main/java/io/geezers/mogakco/security/config/SecurityConfig.java
@@ -48,6 +48,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         http.authorizeRequests()
                 .antMatchers(DEFAULT_ACCESS_WHITELIST).permitAll()
                 .antMatchers(HttpMethod.POST, Endpoint.Api.USER).permitAll()
+                .antMatchers(HttpMethod.GET, Endpoint.Api.AUTH).permitAll()
                 .anyRequest().authenticated();
         http
                 .formLogin().disable();

--- a/src/main/java/io/geezers/mogakco/security/config/SecurityConfig.java
+++ b/src/main/java/io/geezers/mogakco/security/config/SecurityConfig.java
@@ -42,16 +42,29 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {
-        http.csrf().disable();
-        http.headers().frameOptions().disable();
-        http.cors().configurationSource(corsConfigurationSource());
-        http.authorizeRequests()
-                .antMatchers(DEFAULT_ACCESS_WHITELIST).permitAll()
-                .antMatchers(HttpMethod.POST, Endpoint.Api.USER).permitAll()
-                .antMatchers(HttpMethod.GET, Endpoint.Api.AUTH).permitAll()
-                .anyRequest().authenticated();
         http
-                .formLogin().disable();
+                .csrf()
+                .disable();
+        http
+                .headers()
+                .frameOptions()
+                .disable();
+        http
+                .cors()
+                .configurationSource(corsConfigurationSource());
+        http
+                .authorizeRequests()
+                .antMatchers(DEFAULT_ACCESS_WHITELIST)
+                .permitAll()
+                .antMatchers(HttpMethod.POST, Endpoint.Api.USER)
+                .permitAll()
+                .antMatchers(HttpMethod.GET, Endpoint.Api.AUTH)
+                .permitAll()
+                .anyRequest()
+                .authenticated();
+        http
+                .formLogin()
+                .disable();
         http
                 .logout()
                 .logoutUrl(Endpoint.Api.LOGOUT)
@@ -86,7 +99,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     private AuthenticationEntryPoint authenticationEntryPoint() {
         return (request, response, accessDeniedException) -> {
             response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-            objectMapper.writeValue(response.getWriter(), ErrorResponseDto.builder()
+            objectMapper.writeValue(response.getWriter(), ErrorResponseDto
+                    .builder()
                     .message(accessDeniedException.getMessage())
                     .status(HttpServletResponse.SC_UNAUTHORIZED)
                     .build());
@@ -96,7 +110,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     private AccessDeniedHandler accessDeniedHandler() {
         return (request, response, accessDeniedException) -> {
             response.setStatus(HttpServletResponse.SC_FORBIDDEN);
-            objectMapper.writeValue(response.getWriter(), ErrorResponseDto.builder()
+            objectMapper.writeValue(response.getWriter(), ErrorResponseDto
+                    .builder()
                     .message(accessDeniedException.getMessage())
                     .status(HttpServletResponse.SC_FORBIDDEN)
                     .build());
@@ -120,7 +135,9 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     }
 
     private AjaxLoginProcessingFilter ajaxLoginProcessingFilter() {
-        AjaxLoginProcessingFilter ajaxLoginProcessingFilter = new AjaxLoginProcessingFilter(Endpoint.Api.LOGIN, ajaxAuthenticationManager());
+        AjaxLoginProcessingFilter ajaxLoginProcessingFilter = new AjaxLoginProcessingFilter(
+                Endpoint.Api.LOGIN,
+                ajaxAuthenticationManager());
         ajaxLoginProcessingFilter.setAuthenticationManager(ajaxAuthenticationManager());
         ajaxLoginProcessingFilter.setAuthenticationSuccessHandler(authenticationSuccessHandler());
         ajaxLoginProcessingFilter.setAuthenticationFailureHandler(authenticationFailureHandler());

--- a/src/main/java/io/geezers/mogakco/security/filter/AjaxLoginProcessingFilter.java
+++ b/src/main/java/io/geezers/mogakco/security/filter/AjaxLoginProcessingFilter.java
@@ -2,8 +2,8 @@ package io.geezers.mogakco.security.filter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.geezers.mogakco.domain.dto.user.UserLoginRequestDto;
-import io.geezers.mogakco.security.exception.LoginArgumentNotValidException;
 import io.geezers.mogakco.security.exception.AjaxMethodNotSupportedException;
+import io.geezers.mogakco.security.exception.LoginArgumentNotValidException;
 import io.geezers.mogakco.security.token.AjaxAuthenticationToken;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
@@ -26,7 +26,10 @@ public class AjaxLoginProcessingFilter extends AbstractAuthenticationProcessingF
     @Override
     public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException, IOException {
         if (isSupportAjax(request)) {
-            throw new AjaxMethodNotSupportedException(String.format("%s method is not for login. Please use POST with login information.", request.getMethod()));
+            throw new AjaxMethodNotSupportedException(
+                    String.format(
+                            "%s method is not for login. Please use POST with login information.",
+                            request.getMethod()));
         }
         ObjectMapper objectMapper = new ObjectMapper();
 
@@ -41,7 +44,9 @@ public class AjaxLoginProcessingFilter extends AbstractAuthenticationProcessingF
     }
 
     private boolean isSupportAjax(HttpServletRequest request) {
-        return !request.getMethod().equals(HttpMethod.POST.name()) || !isAjax(request);
+        return !request
+                .getMethod()
+                .equals(HttpMethod.POST.name()) || !isAjax(request);
     }
 
     private boolean isBlankLoginRequestDto(UserLoginRequestDto requestDto) {
@@ -49,6 +54,8 @@ public class AjaxLoginProcessingFilter extends AbstractAuthenticationProcessingF
     }
 
     private boolean isAjax(HttpServletRequest request) {
-        return request.getContentType().equals(MediaType.APPLICATION_JSON_VALUE);
+        return request
+                .getContentType()
+                .equals(MediaType.APPLICATION_JSON_VALUE);
     }
 }

--- a/src/main/java/io/geezers/mogakco/security/handler/AjaxAuthenticationFailureHandler.java
+++ b/src/main/java/io/geezers/mogakco/security/handler/AjaxAuthenticationFailureHandler.java
@@ -1,9 +1,9 @@
 package io.geezers.mogakco.security.handler;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.geezers.mogakco.web.dto.error.ErrorResponseDto;
 import io.geezers.mogakco.security.exception.AjaxMethodNotSupportedException;
 import io.geezers.mogakco.security.exception.LoginArgumentNotValidException;
+import io.geezers.mogakco.web.dto.error.ErrorResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.AuthenticationException;
@@ -30,7 +30,8 @@ public class AjaxAuthenticationFailureHandler implements AuthenticationFailureHa
             response.setStatus(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
         }
 
-        ErrorResponseDto errorResponseDto = ErrorResponseDto.builder()
+        ErrorResponseDto errorResponseDto = ErrorResponseDto
+                .builder()
                 .status(response.getStatus())
                 .message(exception.getMessage())
                 .build();

--- a/src/main/java/io/geezers/mogakco/security/handler/AjaxAuthenticationSuccessHandler.java
+++ b/src/main/java/io/geezers/mogakco/security/handler/AjaxAuthenticationSuccessHandler.java
@@ -24,9 +24,10 @@ public class AjaxAuthenticationSuccessHandler implements AuthenticationSuccessHa
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
 
         UserAuthenticationDto userAuthenticationDto = (UserAuthenticationDto) authentication.getPrincipal();
-        objectMapper.writeValue(response.getWriter(), UserLoginResponseDto.of(Me.builder()
-                .id(userAuthenticationDto.getId())
-                .email(userAuthenticationDto.getUsername())
-                .build()));
+        objectMapper.writeValue(response.getWriter(), UserLoginResponseDto.of(Me
+                                                                                      .builder()
+                                                                                      .id(userAuthenticationDto.getId())
+                                                                                      .email(userAuthenticationDto.getUsername())
+                                                                                      .build()));
     }
 }

--- a/src/main/java/io/geezers/mogakco/security/service/UserDetailsServiceImpl.java
+++ b/src/main/java/io/geezers/mogakco/security/service/UserDetailsServiceImpl.java
@@ -26,7 +26,8 @@ public class UserDetailsServiceImpl implements UserDetailsService {
             throw new UsernameNotFoundException(String.format("No User founded with email: %s", email));
         }
 
-        return UserAuthenticationDto.builder()
+        return UserAuthenticationDto
+                .builder()
                 .id(user.getId())
                 .email(user.getEmail())
                 .password(user.getPassword())

--- a/src/main/java/io/geezers/mogakco/service/user/UserService.java
+++ b/src/main/java/io/geezers/mogakco/service/user/UserService.java
@@ -1,6 +1,5 @@
 package io.geezers.mogakco.service.user;
 
-import io.geezers.mogakco.domain.dto.user.Me;
 import io.geezers.mogakco.domain.dto.user.UserSignupRequestDto;
 import io.geezers.mogakco.domain.entity.User;
 import io.geezers.mogakco.exception.AlreadyUserExistingException;

--- a/src/main/java/io/geezers/mogakco/web/config/WebConfig.java
+++ b/src/main/java/io/geezers/mogakco/web/config/WebConfig.java
@@ -1,6 +1,6 @@
 package io.geezers.mogakco.web.config;
 
-import io.geezers.mogakco.api.common.SimpleWeblogFilter;
+import io.geezers.mogakco.web.filter.SimpleWeblogFilter;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/io/geezers/mogakco/web/filter/SimpleWeblogFilter.java
+++ b/src/main/java/io/geezers/mogakco/web/filter/SimpleWeblogFilter.java
@@ -1,4 +1,4 @@
-package io.geezers.mogakco.api.common;
+package io.geezers.mogakco.web.filter;
 
 import lombok.extern.slf4j.Slf4j;
 

--- a/src/test/java/io/geezers/mogakco/api/UserApiControllerTest.java
+++ b/src/test/java/io/geezers/mogakco/api/UserApiControllerTest.java
@@ -16,6 +16,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpSession;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.security.test.context.support.WithMockUser;
@@ -53,26 +54,30 @@ class UserApiControllerTest {
 
     @BeforeEach
     public void setUp(WebApplicationContext webApplicationContext, RestDocumentationContextProvider restDocumentation) {
-        this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
+        this.mockMvc = MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
                 .apply(documentationConfiguration(restDocumentation)
-                        .operationPreprocessors()
-                        .withRequestDefaults(prettyPrint(), removeHeaders("Host"))
-                        .withResponseDefaults(prettyPrint()))
-                .apply(springSecurity()).build();
+                               .operationPreprocessors()
+                               .withRequestDefaults(prettyPrint(), removeHeaders("Host"))
+                               .withResponseDefaults(prettyPrint()))
+                .apply(springSecurity())
+                .build();
     }
 
     @DisplayName("인증 상태 검증 성공")
-    @WithMockUser
     @Test
     void testAuthenticationVerifyingSuccess() throws Exception {
-        mockMvc.perform(get(Endpoint.Api.AUTH))
+        MockHttpSession mockHttpSession = new MockHttpSession();
+        mockMvc
+                .perform(get(Endpoint.Api.AUTH).session(mockHttpSession))
                 .andExpect(status().isOk());
     }
 
     @DisplayName("인증 상태 검증 실패")
     @Test
     void testAuthenticationVerifyingFailed() throws Exception {
-        mockMvc.perform(get(Endpoint.Api.AUTH))
+        mockMvc
+                .perform(get(Endpoint.Api.AUTH))
                 .andExpect(status().isUnauthorized());
     }
 
@@ -81,25 +86,28 @@ class UserApiControllerTest {
     void testSignupIsSuccess() throws Exception {
         UserSignupRequestDto signupRequestDto = getUserSignupRequestDto(getValidEmail(), getValidPassword());
 
-        mockMvc.perform(post(Endpoint.Api.USER)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(signupRequestDto)))
+        mockMvc
+                .perform(post(Endpoint.Api.USER)
+                                 .contentType(MediaType.APPLICATION_JSON)
+                                 .content(objectMapper.writeValueAsString(signupRequestDto)))
                 .andExpect(status().isCreated())
-                .andDo(document("signup",
-                        requestFields(
-                                attributes(
-                                        key("title").value("Data Params"), key("url").value(Endpoint.Api.USER),
-                                        key("method").value("POST")),
-                                fieldWithPath("email").description("").
-                                        attributes(key("required").value("O"))
-                                        .attributes(key("constraints").value("@Email 형식을 맞추어야 함")),
-                                fieldWithPath("password").description("")
-                                        .attributes(key("required").value("O"))
-                                        .attributes(key("constraints").value("Null 불가, 빈 문자열 불가")))));
+                .andDo(document("signup", requestFields(
+                        attributes(key("title").value("Data Params"), key("url").value(Endpoint.Api.USER),
+                                   key("method").value("POST")), fieldWithPath("email")
+                                .description("")
+                                .attributes(key("required").value("O"))
+                                .attributes(key("constraints").value("@Email 형식을 맞추어야 함")), fieldWithPath("password")
+                                .description("")
+                                .attributes(key("required").value("O"))
+                                .attributes(key("constraints").value("Null 불가, 빈 문자열 불가")))));
     }
 
     private UserSignupRequestDto getUserSignupRequestDto(String email, String password) {
-        return UserSignupRequestDto.builder().email(email).password(password).build();
+        return UserSignupRequestDto
+                .builder()
+                .email(email)
+                .password(password)
+                .build();
     }
 
     private String getValidPassword() {
@@ -117,9 +125,10 @@ class UserApiControllerTest {
         UserSignupRequestDto signupRequestDto = getUserSignupRequestDto(getValidEmail(), getValidPassword());
         userApiController.signup(signupRequestDto, request);
 
-        mockMvc.perform(post(Endpoint.Api.USER)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(signupRequestDto)))
+        mockMvc
+                .perform(post(Endpoint.Api.USER)
+                                 .contentType(MediaType.APPLICATION_JSON)
+                                 .content(objectMapper.writeValueAsString(signupRequestDto)))
                 .andExpect(status().isConflict());
     }
 
@@ -129,9 +138,10 @@ class UserApiControllerTest {
     void testSignupIsFailedByEmailFormat(String invalidEmail) throws Exception {
         UserSignupRequestDto signupRequestDto = getUserSignupRequestDto(invalidEmail, getValidPassword());
 
-        mockMvc.perform(post(Endpoint.Api.USER)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(signupRequestDto)))
+        mockMvc
+                .perform(post(Endpoint.Api.USER)
+                                 .contentType(MediaType.APPLICATION_JSON)
+                                 .content(objectMapper.writeValueAsString(signupRequestDto)))
                 .andExpect(status().isBadRequest());
     }
 
@@ -141,9 +151,10 @@ class UserApiControllerTest {
     void testSignupIsFailedByEmptyEmail(String emptyEmail) throws Exception {
         UserSignupRequestDto signupRequestDto = getUserSignupRequestDto(emptyEmail, getValidPassword());
 
-        mockMvc.perform(post(Endpoint.Api.USER)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(signupRequestDto)))
+        mockMvc
+                .perform(post(Endpoint.Api.USER)
+                                 .contentType(MediaType.APPLICATION_JSON)
+                                 .content(objectMapper.writeValueAsString(signupRequestDto)))
                 .andExpect(status().isBadRequest());
     }
 
@@ -153,9 +164,10 @@ class UserApiControllerTest {
     void testSignupIsFailedByEmptyPassword(String emptyPassword) throws Exception {
         UserSignupRequestDto signupRequestDto = getUserSignupRequestDto(getValidEmail(), emptyPassword);
 
-        mockMvc.perform(post(Endpoint.Api.USER)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(signupRequestDto)))
+        mockMvc
+                .perform(post(Endpoint.Api.USER)
+                                 .contentType(MediaType.APPLICATION_JSON)
+                                 .content(objectMapper.writeValueAsString(signupRequestDto)))
                 .andExpect(status().isBadRequest());
     }
 
@@ -169,25 +181,28 @@ class UserApiControllerTest {
 
         UserLoginRequestDto loginRequestDto = getLoginRequestDto(getValidEmail(), getValidPassword());
 
-        mockMvc.perform(post(Endpoint.Api.LOGIN)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(loginRequestDto)))
+        mockMvc
+                .perform(post(Endpoint.Api.LOGIN)
+                                 .contentType(MediaType.APPLICATION_JSON)
+                                 .content(objectMapper.writeValueAsString(loginRequestDto)))
                 .andExpect(status().isOk())
-                .andDo(document("login",
-                        requestFields(
-                                attributes(
-                                        key("title").value("Data Params"), key("url").value(Endpoint.Api.LOGIN),
-                                        key("method").value("POST")),
-                                fieldWithPath("email").description("").
-                                        attributes(key("required").value("O"))
-                                        .attributes(key("constraints").value("@Email 형식을 맞추어야 함")),
-                                fieldWithPath("password").description("")
-                                        .attributes(key("required").value("O"))
-                                        .attributes(key("constraints").value("Null 불가, 빈 문자열 불가")))));
+                .andDo(document("login", requestFields(
+                        attributes(key("title").value("Data Params"), key("url").value(Endpoint.Api.LOGIN),
+                                   key("method").value("POST")), fieldWithPath("email")
+                                .description("")
+                                .attributes(key("required").value("O"))
+                                .attributes(key("constraints").value("@Email 형식을 맞추어야 함")), fieldWithPath("password")
+                                .description("")
+                                .attributes(key("required").value("O"))
+                                .attributes(key("constraints").value("Null 불가, 빈 문자열 불가")))));
     }
 
     private UserLoginRequestDto getLoginRequestDto(String email, String password) {
-        return UserLoginRequestDto.builder().email(email).password(password).build();
+        return UserLoginRequestDto
+                .builder()
+                .email(email)
+                .password(password)
+                .build();
     }
 
     @DisplayName("회원가입 하지 않은 이메일로 로그인 시도로 인한 로그인 실패")
@@ -195,9 +210,10 @@ class UserApiControllerTest {
     void testLoginIsFailedByNotExistEmail() throws Exception {
         UserLoginRequestDto loginRequestDto = getLoginRequestDto(getNotExistEmail(), getValidPassword());
 
-        mockMvc.perform(post(Endpoint.Api.LOGIN)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(loginRequestDto)))
+        mockMvc
+                .perform(post(Endpoint.Api.LOGIN)
+                                 .contentType(MediaType.APPLICATION_JSON)
+                                 .content(objectMapper.writeValueAsString(loginRequestDto)))
                 .andExpect(status().isUnauthorized());
     }
 
@@ -211,9 +227,10 @@ class UserApiControllerTest {
     void testLoginIsFailedByEmailFormat(String invalidEmail) throws Exception {
         UserLoginRequestDto loginRequestDto = getLoginRequestDto(invalidEmail, getValidPassword());
 
-        mockMvc.perform(post(Endpoint.Api.LOGIN)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(loginRequestDto)))
+        mockMvc
+                .perform(post(Endpoint.Api.LOGIN)
+                                 .contentType(MediaType.APPLICATION_JSON)
+                                 .content(objectMapper.writeValueAsString(loginRequestDto)))
                 .andExpect(status().isUnauthorized());
     }
 
@@ -223,9 +240,10 @@ class UserApiControllerTest {
     void testLoginIsFailedByEmptyEmail(String emptyEmail) throws Exception {
         UserLoginRequestDto loginRequestDto = getLoginRequestDto(emptyEmail, getValidPassword());
 
-        mockMvc.perform(post(Endpoint.Api.LOGIN)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(loginRequestDto)))
+        mockMvc
+                .perform(post(Endpoint.Api.LOGIN)
+                                 .contentType(MediaType.APPLICATION_JSON)
+                                 .content(objectMapper.writeValueAsString(loginRequestDto)))
                 .andExpect(status().isBadRequest());
     }
 
@@ -235,9 +253,10 @@ class UserApiControllerTest {
     void testLoginIsFailedByEmptyPassword(String emptyPassword) throws Exception {
         UserLoginRequestDto loginRequestDto = getLoginRequestDto(getValidEmail(), emptyPassword);
 
-        mockMvc.perform(post(Endpoint.Api.LOGIN)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(loginRequestDto)))
+        mockMvc
+                .perform(post(Endpoint.Api.LOGIN)
+                                 .contentType(MediaType.APPLICATION_JSON)
+                                 .content(objectMapper.writeValueAsString(loginRequestDto)))
                 .andExpect(status().isBadRequest());
     }
 
@@ -245,7 +264,8 @@ class UserApiControllerTest {
     @WithMockUser
     @Test
     void testLogoutIsSuccess() throws Exception {
-        mockMvc.perform(post(Endpoint.Api.LOGOUT))
+        mockMvc
+                .perform(post(Endpoint.Api.LOGOUT))
                 .andExpect(status().isOk())
                 .andDo(document("logout"));
     }


### PR DESCRIPTION
# 오류 1. 엔드포인트에 대한 접근을 허용하지 않음
1. Controller 단에서 Authentication 객체는 로그인한 경우에만 주입되고 로그인하지 않은 상태에서는 null이 주입된다.
2. 이 API는 로그인하지 않은 상태에서 세션 ID를 검증해야 하는데  수정 전의 코드는 로그인하지 않으면 세션 ID가 정상이어도 API를 호출할 수 없었다.

# 오류 2. Authentication 객체 주입에 대한 잘못된 이해로 인한 잘못된 로직 작성
1. 1-2과 같은 이유로 로그인하지 않은 유저가 호출 시 Authentication 객체에는 null이 할당된다.
2. 따라서 401 Unauthorized가 아닌 NPE로 인한 500 에러가 발생한다.